### PR TITLE
add ability to define several server directives.

### DIFF
--- a/templates/etc/nginx/sites-available/vhost.j2
+++ b/templates/etc/nginx/sites-available/vhost.j2
@@ -25,10 +25,12 @@ server {
 }
 
 {% if item.ssl_enabled is defined and item.ssl_enabled %}
+{% for server_name in item.server_list %}
+  
 server {
 
   listen {{item.listen_ssl|default('443')}};
-  server_name {{item.server_name}};
+  server_name {{server_name}};
 
   ssl on;
   ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
@@ -46,6 +48,7 @@ server {
 {%   for d in item.https_directives %}
   {{d}}
 {%   endfor %}
+{% endfor %}
 {% endif %}
 
 }


### PR DESCRIPTION
In case of using ELB, if you want to add redirect to url with www, normal rewrite rule will not work because ELB expects only 200 response code, but in case of rewrite rule nginx response with code 300. The solution is add additional server directive. I extend  template with variable server_list and add for loop.
