### PR TITLE
Add nginx listen extra parameters

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -111,10 +111,8 @@ nginx_config: {}
 #    root: /var/www/foo.bar/html
 #    # Add extra parameters to listen directive
 #    listen_parameters:
-#     - name: backlog
-#       value: 1024
-#     - name: so_keepalive
-#       value: "on"
+#     - backlog=1024
+#     - spdy
 #    # If you have defined a log format on the nginx_config settings
 #    # you can reference it in a virtualhost defining log_fmt
 #    log_fmt: format_name

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -43,7 +43,7 @@ nginx_context_http_default: |
   sendfile    on;
   tcp_nopush  on;
   tcp_nodelay on;
-  
+
   include {{nginx_prefix}}/mime.types;
   default_type application/octet-stream;
 
@@ -58,13 +58,13 @@ nginx_context_http_default: |
   #gzip_comp_level 6;
   #gzip_buffers 16 8k;
   #gzip_http_version 1.1;
-  #gzip_types text/plain 
-  #   text/css 
-  #   application/json 
-  #   application/x-javascript 
-  #   text/xml 
-  #   application/xml 
-  #   application/xml+rss 
+  #gzip_types text/plain
+  #   text/css
+  #   application/json
+  #   application/x-javascript
+  #   text/xml
+  #   application/xml
+  #   application/xml+rss
   #   text/javascript;
 
 
@@ -101,7 +101,7 @@ nginx_workers: 4
 #       '"$http_x_forwarded_for" $request_time';
 #
 nginx_config: {}
-  
+
 
 # Nginx Vhosts example
 #
@@ -109,6 +109,12 @@ nginx_config: {}
 #  # Each item on the list, represents a virtualhost configuration
 #  - server_name: foo.bar
 #    root: /var/www/foo.bar/html
+#    # Add extra parameters to listen directive
+#    listen_parameters:
+#     - name: backlog
+#       value: 1024
+#     - name: so_keepalive
+#       value: "on"
 #    # If you have defined a log format on the nginx_config settings
 #    # you can reference it in a virtualhost defining log_fmt
 #    log_fmt: format_name
@@ -141,7 +147,7 @@ nginx_config: {}
 #
 #    http_directives: |
 #        return 301 https://$host$request_uri;
-#     
+#
 #    https_directives: []
 #
 nginx_vhosts: []

--- a/templates/etc/nginx/sites-available/vhost.j2
+++ b/templates/etc/nginx/sites-available/vhost.j2
@@ -5,7 +5,7 @@ server {
   listen {{item.listen|default('80')}} {% if item.default_server is defined and item.default_server %}default_server{% endif %}
   {%- if item.listen_parameters is defined %}
     {%- for param in item.listen_parameters %}
-      {{param.name}}={{param.value}}
+      {{param}}
     {%- endfor %}
   {%- endif %};
 
@@ -32,7 +32,7 @@ server {
   listen {{item.listen_ssl|default('443')}} {% if item.default_server is defined and item.default_server %}default_server{% endif %}
   {%- if item.listen_parameters is defined %}
     {%- for param in item.listen_parameters %}
-      {{param.name}}={{param.value}}
+      {{param}}
     {%- endfor %}
   {%- endif %};
 

--- a/templates/etc/nginx/sites-available/vhost.j2
+++ b/templates/etc/nginx/sites-available/vhost.j2
@@ -2,7 +2,13 @@
 
 server {
 
-  listen {{item.listen|default('80')}} {% if item.default_server is defined and item.default_server %}default_server{% endif %};
+  listen {{item.listen|default('80')}} {% if item.default_server is defined and item.default_server %}default_server{% endif %}
+  {%- if item.listen_parameters is defined %}
+    {%- for param in item.listen_parameters %}
+      {{param.name}}={{param.value}}
+    {%- endfor %}
+  {%- endif %};
+
   server_name {{item.server_name}}
 {% if item.server_aliases is defined %}
 {%   for a in item.server_aliases %}
@@ -23,13 +29,19 @@ server {
 {% if item.ssl_enabled is defined and item.ssl_enabled %}
 server {
 
-  listen {{item.listen_ssl|default('443')}} {% if item.default_server is defined and item.default_server %}default_server{% endif %};
+  listen {{item.listen_ssl|default('443')}} {% if item.default_server is defined and item.default_server %}default_server{% endif %}
+  {%- if item.listen_parameters is defined %}
+    {%- for param in item.listen_parameters %}
+      {{param.name}}={{param.value}}
+    {%- endfor %}
+  {%- endif %};
+
   server_name {{item.server_name}};
 
   ssl on;
   ssl_certificate         {{nginx_ssl_dir}}/{{item.server_name}}.pem;
   ssl_certificate_key     {{nginx_ssl_dir}}/{{item.server_name}}.key;
-  
+
 {% if item.root is defined %}
   root {{item.root}};
 {% endif %}


### PR DESCRIPTION
In some cases we need to add extra key/value parameters to listen directive. This PR allows it keeping backwards compatibility.
List of possible nginx listen parameters [here](http://nginx.org/en/docs/http/ngx_http_core_module.html#listen)